### PR TITLE
Update read me for public access

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ By default, GitHub  does not apply any branch protection policies to newly creat
 ### Installation
 ## Getting Started
 
-### Set up your local development environment (for DLUHC set up)
+### Set up your local development environment (DLUHC set up - others may vary)
 **Note: This section only needs completing once**
 1.  Set your default browser to Google Chrome - [instructions][Make Chrome your default browser].
 1.  Open Anaconda Navigator via Start menu. **Note:** Anaconda asks if you want to update it, but it won't work.
@@ -68,7 +68,6 @@ git config --global user.email "Your.Name@levellingup.gov.uk"
 1.  Install the [Microsoft Python][python_extension] extension for VS Code.
 1.  Follow the [instructions for configuring the Python interpreter][configure_python_interpreter].
 
- **Note: If in DLUHC and get an error when creating conda environment check conda version. Type 'conda --version' in VS Code terminal. conda 4.5.12 needs to be upgraded to 4.10.3. Contact DAP-support@communities.gov.uk**
 
 [open-terminal]: https://code.visualstudio.com/docs/editor/integrated-terminal
 [terminal-switch]: https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-shells
@@ -177,17 +176,4 @@ The linter checks for basic logic errors and bugs. Linting reports rule violatio
 
 ```bash
 pylint <Dashboard name>
-```
-
-###  Add reminder message to run formatter and linter before pushing to GitHub
-
-
-1.  On VS Code go to File - Preferences - Settings
-1.  Search for files.exclude
-1.  Mouse over "**/.git", and click the cross icon
-1.  In the explorer navigate to .git/hooks/ and create a new file called pre-commit. Paste the below command into the file: 
-
-```bash
-#!/usr/bin/env bash
-echo "Remember to run Black and Pylint before pushing to GitHub" 
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,73 @@ By default, GitHub  does not apply any branch protection policies to newly creat
 
 
 ### Installation
-1. Follow the [Getting Started instructions](https://github.com/communitiesuk/plotly_dashboard_docs/blob/main/README.md) to the end of Running the application
+## Getting Started
+
+### Set up your local development environment (for DLUHC set up)
+**Note: This section only needs completing once**
+1.  Set your default browser to Google Chrome - [instructions][Make Chrome your default browser].
+1.  Open Anaconda Navigator via Start menu. **Note:** Anaconda asks if you want to update it, but it won't work.
+1.  Install and launch VS Code (Visual Studio Code) from within the Anaconda Navigator. **Note** after installing VS Code, a Getting Started walkthrough is shown. Click the back button to escape.
+1.  Navigate to the `Git CMD` from the start menu and execute the below commands. Once you have executed the commands close `Git CMD`.
+
+    **Note: You need to change the name/email to match your own and you need to include the quotation marks. You may like to copy the commands into a word document to edit them.**
+
+```shell
+git config --global user.name "Your Name"
+git config --global user.email "Your.Name@levellingup.gov.uk"
+``` 
+
+[Make Chrome your default browser]: https://support.google.com/chrome/answer/95417?hl=en-GB&co=GENIE.Platform%3DDesktop
+
+### Downloading the code from GitHub
+
+1.  Create a folder on your desktop, for storing source code within if you don't have one already.
+1.  From VS Code open the [Explorer window][explorer_window], the overlapping pages icon on left hand menu. Select the option to "Clone Repository". Click "Clone from GitHub"
+1.  If prompted, authorize with GitHub.
+1.  You should be prompted to enter a repository name. Type "communitiesuk/&lt;Your repository name&gt;". Then click on communitiesuk/&lt;Your repository name&gt;.
+1.  As a destination, select your folder for storing the source code. Select "Sign in with browser" if the GitHub authorisation popup is shown.
+1.  This pulls the code from GitHub to your local folder.
+    Click "Open folder" option, and navigate to your newly created folder containing the repository code.
+1.  Select "Yes, I trust the authors".
+
+[explorer_window]: https://code.visualstudio.com/docs/getstarted/userinterface#_explorer
+
+### Installing packages
+
+1.  [Open a command prompt terminal within VS Code][open-terminal], in which you'll start executing some commands. By default, the initial terminal will be a powershell terminal, and you will need to [switch to a command prompt shell][terminal-switch]. 
+1.  Update the name field in environment.yml to the dashboard name
+1.  Create a new conda environment by typing `conda env create -f environment.yml` into the terminal and executing the command by pressing the Enter key.
+1.  Activate your conda environment with `conda activate <dashboard name> `
+1. Close VS Code. Open Anaconda Navigator, select "&lt; Dashboard name &gt;" for the 'Application on' drop down menu, then select "Launch" VS Code. Click the bin icon on the terminal toolbar to close the terminal. Click the plus icon on the terminal toolbar to launch a new terminal.
+1.  Install the [Microsoft Python][python_extension] extension for VS Code.
+1.  Follow the [instructions for configuring the Python interpreter][configure_python_interpreter].
+
+ **Note: If in DLUHC and get an error when creating conda environment check conda version. Type 'conda --version' in VS Code terminal. conda 4.5.12 needs to be upgraded to 4.10.3. Contact DAP-support@communities.gov.uk**
+
+[open-terminal]: https://code.visualstudio.com/docs/editor/integrated-terminal
+[terminal-switch]: https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-shells
+[python_extension]: https://marketplace.visualstudio.com/items?itemName=ms-python.python
+[configure_python_interpreter]: https://code.visualstudio.com/docs/python/python-tutorial#_select-a-python-interpreter
+
+### Configuring GitHub triggers
+
+1. Navigate to `check-before-merging.yml` in the workflows folder
+1. Uncomment the GitHub triggers for the Automated checks
+1. Update the application-name environment variable to the application name, which should match the value set in the dashboard.
+
+### Setting environment variables
+1. From VS Code, open the `.env` file. If this file does not exist, then create it at the root of the project. The `.env` file is excluded from git commits, so can contain secrets such as AWS Access keys as they will only be present on an individual developer laptop
+1. Inside the `.env file`, add the new environment variable in the format `ENVIRONMENT_VARIABLE=VALUE`. An example is `STAGE="production"`. There is a file called `.env.example` that be used for reference
+
+
+### Running the application
+1.  From your VS Code terminal, execute `python run.py`
+1.  Wait for the message "Dash is running on ..." message to appear
+1.  Navigate to http://localhost:8080/ in your browser within the AWS workspace. Note that http://localhost:8080/ is the address that dash will run on in your local machine.
+1. Use Ctrl-C in the terminal to quit the python server. 
+
+    **Note:** Terminal can only handle one command at a time, if the python server is running the terminal will not handle any further commands. To restart the server use `python run.py`
+
 
 
 ## Customisation 
@@ -86,3 +152,42 @@ More information on secrets can be found [here](https://docs.github.com/en/actio
 [store_creds]: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
 [basic_auth]: https://docs.cloud.service.gov.uk/deploying_services/route_services/#example-route-service-to-add-username-and-password-authentication
 
+
+## Development
+
+### Running tests
+
+Writing and running automated tests ensures software is correct, reduces risk that users will experience bugs, and allows developers to move much faster as they can make changes with confidence that any breaks will be caught be the test suite. Once you have set up unit tests:
+
+```bash
+python -u -m pytest tests
+```
+
+### Running the code formatter
+
+The [code formatter](https://black.readthedocs.io/en/stable/) ensures source code is formatted consistently. Running the code formatter makes changes automatically that then need to be committed.
+
+```bash
+black ./
+```
+
+### Running the linter
+
+The linter checks for basic logic errors and bugs. Linting reports rule violations that must be corrected manually.  
+
+```bash
+pylint <Dashboard name>
+```
+
+###  Add reminder message to run formatter and linter before pushing to GitHub
+
+
+1.  On VS Code go to File - Preferences - Settings
+1.  Search for files.exclude
+1.  Mouse over "**/.git", and click the cross icon
+1.  In the explorer navigate to .git/hooks/ and create a new file called pre-commit. Paste the below command into the file: 
+
+```bash
+#!/usr/bin/env bash
+echo "Remember to run Black and Pylint before pushing to GitHub" 
+```


### PR DESCRIPTION
## Pull request checklist

- [x] Add a descriptive message for this change to the PR
- [x] Run `black ./` locally
- [ ] Run `pylint <dashboard name>` locally and obtain a score of 10.00/10.00
- [ ] Run `python -u -m pytest --headless tests` locally and there are no failures
- [ ] Include screenshot for any visual changes
- [ ] Use cds_to_staging.py to push any new or updated data to the S3 bucket


### PR Description:
Copied important information from plotly docs for public access.

Due to making plotly docs private we've decided to update the template read.me to be useful to external users who want to copy the template. We considered that this may cause duplication as each repository based off the template will have it's own documentation. 
A positive is that the documentation will match the state of the template when it was copied. 
A negative is that future updates will need to be made across repositories.