### PR TITLE
Remove references to S3 from template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,5 @@
 - [ ] Run `pylint <dashboard name>` locally and obtain a score of 10.00/10.00
 - [ ] Run `python -u -m pytest --headless tests` locally and there are no failures
 - [ ] Include screenshot for any visual changes
-- [ ] Use cds_to_staging.py to push any new or updated data to the S3 bucket
 
 ### PR Description:


### PR DESCRIPTION
## Pull request checklist

- [ ] Add a descriptive message for this change to the PR
- [ ] Run `black ./` locally
- [ ] Run `pylint <dashboard name>` locally and obtain a score of 10.00/10.00
- [ ] Run `python -u -m pytest --headless tests` locally and there are no failures
- [ ] Include screenshot for any visual changes

### PR Description:

This is the only reference to S3 within the template, so rather confusing!